### PR TITLE
Added fallback values for optional values in the response body

### DIFF
--- a/src/Receipts/ReceiptResponse.php
+++ b/src/Receipts/ReceiptResponse.php
@@ -26,7 +26,7 @@ class ReceiptResponse
     protected $isRetryable;
 
     /**
-     * @var string
+     * @var string|null
      */
     protected $latestReceipt;
 
@@ -63,7 +63,7 @@ class ReceiptResponse
         }
 
         $this->environment = $attributes['environment'];
-        $this->latestReceipt = $attributes['latest_receipt'] ?? '';
+        $this->latestReceipt = $attributes['latest_receipt'] ?? null;
 
         $this->latestReceiptInfo = [];
         foreach ($attributes['latest_receipt_info'] ?? [] as $itemAttributes) {
@@ -100,7 +100,7 @@ class ReceiptResponse
     /**
      * @return string
      */
-    public function getLatestReceipt(): string
+    public function getLatestReceipt(): ?string
     {
         return $this->latestReceipt;
     }

--- a/src/Receipts/ReceiptResponse.php
+++ b/src/Receipts/ReceiptResponse.php
@@ -63,7 +63,7 @@ class ReceiptResponse
         }
 
         $this->environment = $attributes['environment'];
-        $this->latestReceipt = $attributes['latest_receipt'] ?? [];
+        $this->latestReceipt = $attributes['latest_receipt'] ?? '';
 
         $this->latestReceiptInfo = [];
         foreach ($attributes['latest_receipt_info'] ?? [] as $itemAttributes) {

--- a/src/Receipts/ReceiptResponse.php
+++ b/src/Receipts/ReceiptResponse.php
@@ -63,19 +63,18 @@ class ReceiptResponse
         }
 
         $this->environment = $attributes['environment'];
-        $this->latestReceipt = $attributes['latest_receipt'];
+        $this->latestReceipt = $attributes['latest_receipt'] ?? [];
 
         $this->latestReceiptInfo = [];
-        foreach ($attributes['latest_receipt_info'] as $itemAttributes) {
+        foreach ($attributes['latest_receipt_info'] ?? [] as $itemAttributes) {
             $this->latestReceiptInfo[] = ReceiptInfo::fromArray($itemAttributes);
         }
 
         $this->receipt = isset($attributes['receipt']) ? Receipt::fromArray($attributes['receipt']) : null;
         $this->status = new Status($attributes['status']);
 
-        $attributes['pending_renewal_info'] = $attributes['pending_renewal_info'] ?? [];
         $this->pendingRenewalInfo = [];
-        foreach ($attributes['pending_renewal_info'] as $item) {
+        foreach ($attributes['pending_renewal_info'] ?? [] as $item) {
             $this->pendingRenewalInfo[] = PendingRenewal::fromArray($item);
         }
 


### PR DESCRIPTION
As stated in the [documentation by Apple](https://developer.apple.com/documentation/appstorereceipts/responsebody) the `latest_receipt`, `latest_receipt_info` and `pending_renewal_info` properties are "only returned for receipts that contain auto-renewable subscriptions".

This PR makes sure that the code doesn't crash if these values are not present. Because when I used a a receipt which didn't had a subscription, I got the following error:

```
Undefined index: latest_receipt in imdhemy/appstore-iap/src/Receipts/ReceiptResponse.php line 66.
```