### PR TITLE
Added getter and consts for ExpirationIntent

### DIFF
--- a/src/ValueObjects/ExpirationIntent.php
+++ b/src/ValueObjects/ExpirationIntent.php
@@ -5,6 +5,12 @@ namespace Imdhemy\AppStore\ValueObjects;
 
 final class ExpirationIntent
 {
+    const VOLUNTARY_CANCEL = 1;
+    const BILLING_ERROR = 2;
+    const DID_NOT_AGREE_PRICE_INCREASE = 3;
+    const PRODUCT_UNAVAILABLE = 4;
+    const UNKNOWN_ERROR = 5;
+    
     private $value;
 
     /**
@@ -14,5 +20,13 @@ final class ExpirationIntent
     public function __construct($value)
     {
         $this->value = $value;
+    }
+
+    /**
+     * @return int
+     */
+    public function getValue(): int
+    {
+        return $this->value;
     }
 }


### PR DESCRIPTION
I'm unsure why it's not possible to get the expiration intent from this class, so I've gone ahead and added a getter for the value.

Additionally, I've added some consts to represent the various values the expiration intent can be.