### PR TITLE
Get expiration intent value

### DIFF
--- a/src/ValueObjects/ExpirationIntent.php
+++ b/src/ValueObjects/ExpirationIntent.php
@@ -5,14 +5,25 @@ namespace Imdhemy\AppStore\ValueObjects;
 
 final class ExpirationIntent
 {
+    /**
+     * @var int
+     */
     private $value;
 
     /**
      * ExpirationIntent constructor.
-     * @param $value
+     * @param int $value
      */
-    public function __construct($value)
+    public function __construct(int $value)
     {
         $this->value = $value;
+    }
+
+    /**
+     * @return int
+     */
+    public function getValue(): int
+    {
+        return $this->value;
     }
 }


### PR DESCRIPTION
The expiration intent values are integer [as documented](https://developer.apple.com/documentation/appstorereceipts/expiration_intent).

1
The customer voluntarily canceled their subscription.

2
Billing error; for example, the customer's payment information was no longer valid.

3
The customer did not agree to a recent price increase.

4
The product was not available for purchase at the time of renewal.

5
Unknown error.

