### PR TITLE
[1.x] Deprecated cancellation value object

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -10,7 +10,8 @@
          beStrictAboutTodoAnnotatedTests="true"
          failOnRisky="true"
          failOnWarning="true"
-         verbose="true">
+         verbose="true"
+         colors="true">
     <testsuites>
         <testsuite name="default">
             <directory suffix="Test.php">tests</directory>

--- a/src/ValueObjects/AutoRenewStatus.php
+++ b/src/ValueObjects/AutoRenewStatus.php
@@ -2,12 +2,15 @@
 
 namespace Imdhemy\AppStore\ValueObjects;
 
+use Stringable;
+
 /**
  * AutoRenewStatus class
  * The renewal status for the auto-renewable subscription.
+ *
  * @see https://developer.apple.com/documentation/appstorereceipts/auto_renew_status?changes=latest_minor
  */
-final class AutoRenewStatus
+final class AutoRenewStatus implements Stringable
 {
     public const WILL_RENEW = 1;
     public const TURNED_OFF = 0;
@@ -15,7 +18,7 @@ final class AutoRenewStatus
     /**
      * @var int
      */
-    private $value;
+    private int $value;
 
     /**
      * @param int $value

--- a/src/ValueObjects/Cancellation.php
+++ b/src/ValueObjects/Cancellation.php
@@ -4,11 +4,11 @@ namespace Imdhemy\AppStore\ValueObjects;
 
 /**
  * Class Cancellation
- * @package Imdhemy\AppStore\ValueObjects
  * Cancellation class represents two separate parts of information from the
  * response body receipt info, the cancellation time and reason.
  * The time and reason are received in two separate keys, but they are logically
  * related either coupled.
+ *
  * @see https://developer.apple.com/documentation/appstorereceipts/responsebody/latest_receipt_info
  */
 final class Cancellation
@@ -20,7 +20,7 @@ final class Cancellation
      * The time the App Store refunded a transaction or revoked it from family sharing.
      * @var Time
      */
-    private $time;
+    private Time $time;
 
     /**
      * The reason for a refunded or revoked transaction.
@@ -31,7 +31,7 @@ final class Cancellation
      * for example, if the customer made the purchase accidentally.
      * @var int
      */
-    private $reason;
+    private int $reason;
 
     /**
      * Cancellation constructor.

--- a/src/ValueObjects/Cancellation.php
+++ b/src/ValueObjects/Cancellation.php
@@ -9,11 +9,19 @@ namespace Imdhemy\AppStore\ValueObjects;
  * The time and reason are received in two separate keys, but they are logically
  * related either coupled.
  *
+ * @deprecated
  * @see https://developer.apple.com/documentation/appstorereceipts/responsebody/latest_receipt_info
  */
 final class Cancellation
 {
+    /**
+     * @deprecated use \Imdhemy\AppStore\ValueObjects\LatestReceiptInfo::CANCELLATION_REASON_APP_ISSUE
+     */
     public const REASON_APP_ISSUE = 1;
+
+    /**
+     * @deprecated use \Imdhemy\AppStore\ValueObjects\LatestReceiptInfo::CANCELLATION_REASON_OTHER
+     */
     public const REASON_OTHER = 0;
 
     /**
@@ -61,6 +69,7 @@ final class Cancellation
     }
 
     /**
+     * @deprecated
      * @return bool
      */
     public function isDueAppIssue(): bool
@@ -69,6 +78,7 @@ final class Cancellation
     }
 
     /**
+     * @deprecated
      * @return bool
      */
     public function isDueAnotherReason(): bool

--- a/src/ValueObjects/ExpirationIntent.php
+++ b/src/ValueObjects/ExpirationIntent.php
@@ -2,12 +2,15 @@
 
 namespace Imdhemy\AppStore\ValueObjects;
 
+use Stringable;
+
 /**
  * ExpirationIntent class
  * The reason a subscription expired
+ *
  * @see https://developer.apple.com/documentation/appstorereceipts/expiration_intent
  */
-final class ExpirationIntent
+final class ExpirationIntent implements Stringable
 {
     public const VOLUNTARY_CANCEL = 1;
     public const BILLING_ERROR = 2;
@@ -18,7 +21,7 @@ final class ExpirationIntent
     /**
      * @var int
      */
-    private $value;
+    private int $value;
 
     /**
      * ExpirationIntent constructor.

--- a/src/ValueObjects/LatestReceiptInfo.php
+++ b/src/ValueObjects/LatestReceiptInfo.php
@@ -4,6 +4,7 @@ namespace Imdhemy\AppStore\ValueObjects;
 
 /**
  * LatestReceiptInfo class which contains in-app purchase transaction
+ *
  * @link https://developer.apple.com/documentation/appstorereceipts/responsebody/latest_receipt_info
  */
 final class LatestReceiptInfo
@@ -37,6 +38,7 @@ final class LatestReceiptInfo
      * A UUID that associates the transaction with a user on your own service.
      * This field is only present if your app supplied an appAccountToken(_:)
      * when the user made the purchase; it’s only present in the sandbox environment.
+     *
      * @see https://developer.apple.com/documentation/storekit/transaction/3749684-appaccounttoken?changes=latest_minor
      * @see https://developer.apple.com/documentation/storekit/product/purchaseoption/3749440-appaccounttoken?changes=latest_minor
      * @var string|null
@@ -44,13 +46,11 @@ final class LatestReceiptInfo
     private ?string $appAccountToken;
 
     /**
-     * @see \Imdhemy\AppStore\ValueObjects\Cancellation::$time
      * @var int|null
      */
     private ?int $cancellationDate;
 
     /**
-     * @see \Imdhemy\AppStore\ValueObjects\Cancellation::$reason
      * @var int|null
      */
     private ?int $cancellationReason;
@@ -58,12 +58,14 @@ final class LatestReceiptInfo
     /**
      * The time a subscription expires or when it will renew,
      * in UNIX epoch time format, in milliseconds.
+     *
      * @var int|null
      */
     private ?int $expiresDate;
 
     /**
      * The relationship of the user with the family-shared purchase to which they have access.
+     *
      * @see https://developer.apple.com/documentation/appstorereceipts/in_app_ownership_type?changes=latest_minor
      * @var string|null
      */
@@ -71,6 +73,7 @@ final class LatestReceiptInfo
 
     /**
      * An indicator of whether an auto-renewable subscription is in the introductory price period.
+     *
      * @see https://developer.apple.com/documentation/appstorereceipts/is_in_intro_offer_period?changes=latest_minor
      * @var string|null
      */
@@ -78,6 +81,7 @@ final class LatestReceiptInfo
 
     /**
      * An indicator of whether an auto-renewable subscription is in the free trial period.
+     *
      * @see https://developer.apple.com/documentation/appstorereceipts/is_trial_period?changes=latest_minor
      * @var string|null
      */
@@ -86,12 +90,14 @@ final class LatestReceiptInfo
     /**
      * An indicator that a subscription has been canceled due to an upgrade.
      * This field is only present for upgrade transactions.
+     *
      * @var bool|string|null
      */
     private $isUpgraded;
 
     /**
      * The offer-reference name of the subscription offer code that the customer redeemed.
+     *
      * @see https://developer.apple.com/documentation/appstorereceipts/offer_code_ref_name?changes=latest_minor
      * @var string|null
      */
@@ -99,12 +105,14 @@ final class LatestReceiptInfo
 
     /**
      * The time of the original app purchase, in UNIX epoch time format, in milliseconds.
+     *
      * @var int|null
      */
     private ?int $originalPurchaseDate;
 
     /**
      * The transaction identifier of the original purchase.
+     *
      * @see https://developer.apple.com/documentation/appstorereceipts/original_transaction_id?changes=latest_minor
      * @var string
      */
@@ -112,12 +120,14 @@ final class LatestReceiptInfo
 
     /**
      * The unique identifier of the product purchased.
+     *
      * @var string
      */
     private string $productId;
 
     /**
      * The identifier of the subscription offer redeemed by the user.
+     *
      * @see https://developer.apple.com/documentation/appstorereceipts/promotional_offer_id?changes=latest_minor
      * @var string|null
      */
@@ -125,18 +135,21 @@ final class LatestReceiptInfo
 
     /**
      * The time the App Store charged the user’s account for a purchased or restored product
+     *
      * @var int|null
      */
     private ?int $purchaseDate;
 
     /**
      * The number of consumable products purchased.
+     *
      * @var int
      */
     private int $quantity;
 
     /**
      * The identifier of the subscription group to which the subscription belongs.
+     *
      * @see https://developer.apple.com/documentation/storekit/skproduct/2981047-subscriptiongroupidentifier?changes=latest_minor
      * @var string|null
      */
@@ -145,12 +158,14 @@ final class LatestReceiptInfo
     /**
      * A unique identifier for purchase events across devices, including subscription-renewal events.
      * This value is the primary key for identifying subscription purchases.
+     *
      * @var string|null
      */
     private ?string $webOrderLineItemId;
 
     /**
      * A unique identifier for a transaction such as a purchase, restore, or renewal.
+     *
      * @see https://developer.apple.com/documentation/appstorereceipts/transaction_id?changes=latest_minor
      * @var string
      */
@@ -172,6 +187,7 @@ final class LatestReceiptInfo
 
     /**
      * @param array $attributes
+     *
      * @return static
      */
     public static function fromArray(array $attributes): self
@@ -318,11 +334,11 @@ final class LatestReceiptInfo
     }
 
     /**
-     * @deprecated use \Imdhemy\AppStore\ValueObjects\LatestReceiptInfo::getCancellationDate()
-     * @deprecated use \Imdhemy\AppStore\ValueObjects\LatestReceiptInfo::getCancellationReason()
-     *
      * @return Cancellation|null
      * @psalm-suppress PossiblyNullArgument
+     * @deprecated     use \Imdhemy\AppStore\ValueObjects\LatestReceiptInfo::getCancellationReason()
+     *
+     * @deprecated     use \Imdhemy\AppStore\ValueObjects\LatestReceiptInfo::getCancellationDate()
      */
     public function getCancellation(): ?Cancellation
     {

--- a/src/ValueObjects/LatestReceiptInfo.php
+++ b/src/ValueObjects/LatestReceiptInfo.php
@@ -19,6 +19,16 @@ final class LatestReceiptInfo
     public const OWNERSHIP_TYPE_PURCHASED = 'PURCHASED';
 
     /**
+     * @const string cancellation reason - app issue
+     */
+    public const CANCELLATION_REASON_APP_ISSUE = '1';
+
+    /**
+     * @const string cancellation reason - other
+     */
+    public const CANCELLATION_REASON_OTHER = '0';
+
+    /**
      * @const string true string value
      */
     private const TRUE = 'true';
@@ -31,47 +41,47 @@ final class LatestReceiptInfo
      * @see https://developer.apple.com/documentation/storekit/product/purchaseoption/3749440-appaccounttoken?changes=latest_minor
      * @var string|null
      */
-    private $appAccountToken;
+    private ?string $appAccountToken;
 
     /**
      * @see \Imdhemy\AppStore\ValueObjects\Cancellation::$time
      * @var int|null
      */
-    private $cancellationDate;
+    private ?int $cancellationDate;
 
     /**
      * @see \Imdhemy\AppStore\ValueObjects\Cancellation::$reason
      * @var int|null
      */
-    private $cancellationReason;
+    private ?int $cancellationReason;
 
     /**
      * The time a subscription expires or when it will renew,
      * in UNIX epoch time format, in milliseconds.
      * @var int|null
      */
-    private $expiresDate;
+    private ?int $expiresDate;
 
     /**
      * The relationship of the user with the family-shared purchase to which they have access.
      * @see https://developer.apple.com/documentation/appstorereceipts/in_app_ownership_type?changes=latest_minor
      * @var string|null
      */
-    private $inAppOwnershipType;
+    private ?string $inAppOwnershipType;
 
     /**
      * An indicator of whether an auto-renewable subscription is in the introductory price period.
      * @see https://developer.apple.com/documentation/appstorereceipts/is_in_intro_offer_period?changes=latest_minor
-     * @var string|bool|null
+     * @var string|null
      */
-    private $isInIntroOfferPeriod;
+    private ?string $isInIntroOfferPeriod;
 
     /**
      * An indicator of whether an auto-renewable subscription is in the free trial period.
      * @see https://developer.apple.com/documentation/appstorereceipts/is_trial_period?changes=latest_minor
-     * @var string|bool|null
+     * @var string|null
      */
-    private $isTrialPeriod;
+    private ?string $isTrialPeriod;
 
     /**
      * An indicator that a subscription has been canceled due to an upgrade.
@@ -85,66 +95,66 @@ final class LatestReceiptInfo
      * @see https://developer.apple.com/documentation/appstorereceipts/offer_code_ref_name?changes=latest_minor
      * @var string|null
      */
-    private $offerCodeRefName;
+    private ?string $offerCodeRefName;
 
     /**
      * The time of the original app purchase, in UNIX epoch time format, in milliseconds.
      * @var int|null
      */
-    private $originalPurchaseDate;
+    private ?int $originalPurchaseDate;
 
     /**
      * The transaction identifier of the original purchase.
      * @see https://developer.apple.com/documentation/appstorereceipts/original_transaction_id?changes=latest_minor
      * @var string
      */
-    private $originalTransactionId;
+    private string $originalTransactionId;
 
     /**
      * The unique identifier of the product purchased.
      * @var string
      */
-    private $productId;
+    private string $productId;
 
     /**
      * The identifier of the subscription offer redeemed by the user.
      * @see https://developer.apple.com/documentation/appstorereceipts/promotional_offer_id?changes=latest_minor
      * @var string|null
      */
-    private $promotionalOfferId;
+    private ?string $promotionalOfferId;
 
     /**
      * The time the App Store charged the user’s account for a purchased or restored product
      * @var int|null
      */
-    private $purchaseDate;
+    private ?int $purchaseDate;
 
     /**
      * The number of consumable products purchased.
      * @var int
      */
-    private $quantity;
+    private int $quantity;
 
     /**
      * The identifier of the subscription group to which the subscription belongs.
      * @see https://developer.apple.com/documentation/storekit/skproduct/2981047-subscriptiongroupidentifier?changes=latest_minor
      * @var string|null
      */
-    private $subscriptionGroupIdentifier;
+    private ?string $subscriptionGroupIdentifier;
 
     /**
      * A unique identifier for purchase events across devices, including subscription-renewal events.
      * This value is the primary key for identifying subscription purchases.
      * @var string|null
      */
-    private $webOrderLineItemId;
+    private ?string $webOrderLineItemId;
 
     /**
      * A unique identifier for a transaction such as a purchase, restore, or renewal.
      * @see https://developer.apple.com/documentation/appstorereceipts/transaction_id?changes=latest_minor
      * @var string
      */
-    private $transactionId;
+    private string $transactionId;
 
     /**
      * @param string $originalTransactionId
@@ -308,6 +318,9 @@ final class LatestReceiptInfo
     }
 
     /**
+     * @deprecated use \Imdhemy\AppStore\ValueObjects\LatestReceiptInfo::getCancellationDate()
+     * @deprecated use \Imdhemy\AppStore\ValueObjects\LatestReceiptInfo::getCancellationReason()
+     *
      * @return Cancellation|null
      * @psalm-suppress PossiblyNullArgument
      */

--- a/src/ValueObjects/PendingRenewal.php
+++ b/src/ValueObjects/PendingRenewal.php
@@ -21,7 +21,7 @@ final class PendingRenewal
      * @see https://developer.apple.com/documentation/storekit/skpayment/1506155-productidentifier
      * @var string
      */
-    private $autoRenewProductId;
+    private string $autoRenewProductId;
 
     /**
      * The current renewal status for the auto-renewable subscription.
@@ -29,7 +29,7 @@ final class PendingRenewal
      * @see https://developer.apple.com/documentation/appstorereceipts/auto_renew_status?changes=latest_minor
      * @var int|null
      */
-    private $autoRenewStatus;
+    private ?int $autoRenewStatus;
 
     /**
      * The reason a subscription expired.
@@ -38,21 +38,21 @@ final class PendingRenewal
      * @see ExpirationIntent
      * @var int|null
      */
-    private $expirationIntent;
+    private ?int $expirationIntent;
 
     /**
      * The time at which the grace period for subscription renewals expires,
      * in UNIX epoch time format, in milliseconds
      * @var int|null
      */
-    private $gracePeriodExpiresDate;
+    private ?int $gracePeriodExpiresDate;
 
     /**
      * A flag that indicates Apple is attempting to renew an expired subscription automatically.
      * @see https://developer.apple.com/documentation/appstorereceipts/is_in_billing_retry_period?changes=latest_minor
      * @var int|null
      */
-    private $isInBillingRetryPeriod;
+    private ?int $isInBillingRetryPeriod;
 
     /**
      * The reference name of a subscription offer that you configured in App Store Connect.
@@ -60,14 +60,14 @@ final class PendingRenewal
      * @var string|null
      * @see https://developer.apple.com/documentation/appstorereceipts/offer_code_ref_name?changes=latest_minor
      */
-    private $offerCodeRefName;
+    private ?string $offerCodeRefName;
 
     /**
      * The transaction identifier of the original purchase.
      * @see https://developer.apple.com/documentation/appstorereceipts/original_transaction_id?changes=latest_minor
      * @var string
      */
-    private $originalTransactionId;
+    private string $originalTransactionId;
 
     /**
      * The price consent status for a subscription price increase.
@@ -77,7 +77,7 @@ final class PendingRenewal
      * describes this key string.
      * @var string|null
      */
-    private $priceConsentStatus;
+    private ?string $priceConsentStatus;
 
     /**
      * The unique identifier of the product purchased.
@@ -87,7 +87,7 @@ final class PendingRenewal
      * @see https://developer.apple.com/documentation/storekit/skpayment?changes=latest_minor
      * @var string
      */
-    private $productId;
+    private string $productId;
 
     /**
      * The identifier of the promotional offer for an auto-renewable subscription
@@ -96,7 +96,7 @@ final class PendingRenewal
      * @see https://developer.apple.com/documentation/appstorereceipts/promotional_offer_id
      * @var string|null
      */
-    private $promotionalOfferId;
+    private ?string $promotionalOfferId;
 
     /**
      * @param string $autoRenewProductId

--- a/src/ValueObjects/Receipt.php
+++ b/src/ValueObjects/Receipt.php
@@ -19,7 +19,7 @@ final class Receipt
      * @var string|null
      * @see \Imdhemy\AppStore\ValueObjects\Receipt::$appItemId
      */
-    private $adamId;
+    private ?string $adamId;
 
     /**
      * Originally, this is 64-bit long integer, so, let's treat is a string
@@ -29,86 +29,86 @@ final class Receipt
      * Apps are assigned this identifier only in production.
      * @var string|null
      */
-    private $appItemId;
+    private ?string $appItemId;
 
     /**
      * The app’s version number. In the sandbox, the value is always "1.0".
      * @var string|null
      */
-    private $applicationVersion;
+    private ?string $applicationVersion;
 
     /**
      * The bundle identifier for the app to which the receipt belongs.
      * @var string|null
      */
-    private $bundleId;
+    private ?string $bundleId;
 
     /**
      * A unique identifier for the app download transaction.
      * @var int|null
      */
-    private $downloadId;
+    private ?int $downloadId;
 
     /**
      * The time the receipt expires for apps purchased through the Volume Purchase Program
      * @var int|null
      */
-    private $expirationDate;
+    private ?int $expirationDate;
 
     /**
      * An array that contains the in-app purchase receipt fields for all in-app purchase transactions.
      * @var array|null
      */
-    private $inApp;
+    private ?array $inApp;
 
     /**
      * The version of the app that the user originally purchased.
      * @var string|null
      */
-    private $originalApplicationVersion;
+    private ?string $originalApplicationVersion;
 
     /**
      * The time of the original app purchase
      * @var int|null
      */
-    private $originalPurchaseDate;
+    private ?int $originalPurchaseDate;
 
     /**
      * The time the user ordered the app available for pre-order.
      * @var int|null
      */
-    private $preOrderDate;
+    private ?int $preOrderDate;
 
     /**
      * The time the App Store generated the receipt
      * @var int|null
      */
-    private $receiptCreationDate;
+    private ?int $receiptCreationDate;
 
     /**
      * The type of receipt generated.
      * The value corresponds to the environment in which the app or VPP purchase was made
      * @var string|null
      */
-    private $receiptType;
+    private ?string $receiptType;
 
     /**
      * The time the request to the verifyReceipt endpoint was processed and the response was generated
      * @var int|null
      */
-    private $requestDate;
+    private ?int $requestDate;
 
     /**
      * An arbitrary number that identifies a revision of your app.
      * In the sandbox, this key's value is “0”
      * @var int|null
      */
-    private $versionExternalIdentifier;
+    private ?int $versionExternalIdentifier;
 
     /**
      * @var bool
      */
-    private $inAppParsed;
+    private bool $inAppParsed;
 
     /**
      * Receipt Constructor

--- a/src/ValueObjects/Status.php
+++ b/src/ValueObjects/Status.php
@@ -43,7 +43,7 @@ final class Status
     /**
      * @var int
      */
-    private $value;
+    private int $value;
 
     /**
      * Status constructor.

--- a/tests/ValueObjects/AutoRenewStatusTest.php
+++ b/tests/ValueObjects/AutoRenewStatusTest.php
@@ -9,13 +9,23 @@ use PHPUnit\Framework\TestCase;
 class AutoRenewStatusTest extends TestCase
 {
     /**
-     * @test
      * @throws Exception
      */
-    public function test_basic_usage()
+    public function test_basic_usage(): void
     {
         $value = [AutoRenewStatus::TURNED_OFF, AutoRenewStatus::WILL_RENEW][random_int(0, 1)];
         $status = new AutoRenewStatus($value);
         $this->assertEquals($value, $status->getValue());
+    }
+
+    /**
+     * @test
+     * @throws Exception
+     */
+    public function it_should_be_stringable(): void
+    {
+        $value = [AutoRenewStatus::TURNED_OFF, AutoRenewStatus::WILL_RENEW][random_int(0, 1)];
+        $status = new AutoRenewStatus($value);
+        $this->assertEquals((string)$value, (string)$status);
     }
 }

--- a/tests/ValueObjects/CancellationTest.php
+++ b/tests/ValueObjects/CancellationTest.php
@@ -7,18 +7,12 @@ use Imdhemy\AppStore\ValueObjects\Cancellation;
 use Imdhemy\AppStore\ValueObjects\Time;
 use PHPUnit\Framework\TestCase;
 
-/**
- * It's obvious that there is no need to test getter method
- * but this test was added to maintain the convention of cover every class
- * with a unit test.
- */
 class CancellationTest extends TestCase
 {
     /**
-     * @test
      * @throws Exception
      */
-    public function test_basic_usage()
+    public function test_basic_usage(): void
     {
         $time = new Time(time() * 1000);
         $reason = [Cancellation::REASON_OTHER, Cancellation::REASON_APP_ISSUE][random_int(0, 1)];
@@ -40,10 +34,9 @@ class CancellationTest extends TestCase
     }
 
     /**
-     * @test
      * @throws Exception
      */
-    public function test_instantiation_using_string_reason()
+    public function test_instantiation_using_string_reason(): void
     {
         $time = new Time(time() * 1000);
         $reason = (string)[Cancellation::REASON_OTHER, Cancellation::REASON_APP_ISSUE][random_int(0, 1)];

--- a/tests/ValueObjects/CancellationTest.php
+++ b/tests/ValueObjects/CancellationTest.php
@@ -7,6 +7,9 @@ use Imdhemy\AppStore\ValueObjects\Cancellation;
 use Imdhemy\AppStore\ValueObjects\Time;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @deprecated
+ */
 class CancellationTest extends TestCase
 {
     /**

--- a/tests/ValueObjects/ExpirationIntentTest.php
+++ b/tests/ValueObjects/ExpirationIntentTest.php
@@ -12,21 +12,32 @@ use PHPUnit\Framework\TestCase;
  */
 class ExpirationIntentTest extends TestCase
 {
+    private const REASONS = [
+        ExpirationIntent::VOLUNTARY_CANCEL,
+        ExpirationIntent::BILLING_ERROR,
+        ExpirationIntent::DID_NOT_AGREE_PRICE_INCREASE,
+        ExpirationIntent::PRODUCT_UNAVAILABLE,
+        ExpirationIntent::UNKNOWN_ERROR,
+    ];
+
+    public function test_basic_usage(): void
+    {
+        $reason = self::REASONS[array_rand(self::REASONS)];
+
+        $expirationIntent = new ExpirationIntent($reason);
+
+        $this->assertEquals($reason, $expirationIntent->getValue());
+    }
+
     /**
      * @test
      */
-    public function test_basic_usage()
+    public function it_should_be_stringable(): void
     {
-        $reasons = [
-            ExpirationIntent::VOLUNTARY_CANCEL,
-            ExpirationIntent::BILLING_ERROR,
-            ExpirationIntent::DID_NOT_AGREE_PRICE_INCREASE,
-            ExpirationIntent::PRODUCT_UNAVAILABLE,
-            ExpirationIntent::UNKNOWN_ERROR,
-        ];
-        $reason = $reasons[array_rand($reasons)];
+        $reason = self::REASONS[array_rand(self::REASONS)];
 
         $expirationIntent = new ExpirationIntent($reason);
-        $this->assertEquals($reason, $expirationIntent->getValue());
+
+        $this->assertEquals((string)$reason, (string)$expirationIntent);
     }
 }

--- a/tests/ValueObjects/LatestReceiptInfoTest.php
+++ b/tests/ValueObjects/LatestReceiptInfoTest.php
@@ -3,7 +3,6 @@
 namespace Imdhemy\AppStore\Tests\ValueObjects;
 
 use Imdhemy\AppStore\Tests\TestCase;
-use Imdhemy\AppStore\ValueObjects\Cancellation;
 use Imdhemy\AppStore\ValueObjects\LatestReceiptInfo;
 use Imdhemy\AppStore\ValueObjects\Time;
 
@@ -19,7 +18,7 @@ class LatestReceiptInfoTest extends TestCase
      */
     public function trueOrNullDataProvider(): array
     {
-        return[
+        return [
             'true' => ['true', true],
             'null' => [null, null],
         ];
@@ -85,7 +84,7 @@ class LatestReceiptInfoTest extends TestCase
      */
     public function cancellation_reason(): void
     {
-        $reasons = [Cancellation::REASON_OTHER, Cancellation::REASON_APP_ISSUE];
+        $reasons = [LatestReceiptInfo::CANCELLATION_REASON_APP_ISSUE, LatestReceiptInfo::CANCELLATION_REASON_OTHER];
         $value = $this->faker->randomElement($reasons);
         $attributes = array_merge($this->commonAttributes, ['cancellation_reason' => (string)$value]);
         $latestReceiptInfo = LatestReceiptInfo::fromArray($attributes);
@@ -211,12 +210,15 @@ class LatestReceiptInfoTest extends TestCase
         ];
 
         $latestReceiptInfo = LatestReceiptInfo::fromArray($this->commonAttributes);
-        $getters = array_filter(get_class_methods($latestReceiptInfo), static function (string $method) use ($notNullGetters) {
-            $isGetter = strpos($method, 'get') !== false;
-            $isNullGetter = ! in_array($method, $notNullGetters);
+        $getters = array_filter(
+            get_class_methods($latestReceiptInfo),
+            static function (string $method) use ($notNullGetters) {
+                $isGetter = strpos($method, 'get') !== false;
+                $isNullGetter = ! in_array($method, $notNullGetters);
 
-            return $isGetter && $isNullGetter;
-        });
+                return $isGetter && $isNullGetter;
+            }
+        );
 
         foreach ($getters as $getter) {
             $this->assertNull($latestReceiptInfo->$getter());

--- a/tests/ValueObjects/LatestReceiptInfoTest.php
+++ b/tests/ValueObjects/LatestReceiptInfoTest.php
@@ -12,7 +12,18 @@ class LatestReceiptInfoTest extends TestCase
     /**
      * @var string[]
      */
-    private $commonAttributes;
+    private array $commonAttributes;
+
+    /**
+     * @return array[<string, array>]
+     */
+    public function trueOrNullDataProvider(): array
+    {
+        return[
+            'true' => ['true', true],
+            'null' => [null, null],
+        ];
+    }
 
     /**
      * @inheritDoc
@@ -20,6 +31,7 @@ class LatestReceiptInfoTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
+
         $this->commonAttributes = [
             "quantity" => "1",
             "product_id" => "fake_product_id",
@@ -31,7 +43,7 @@ class LatestReceiptInfoTest extends TestCase
     /**
      * @test
      */
-    public function test_required_attributes()
+    public function required_attributes(): void
     {
         $quantity = "1";
         $productId = "fake_product_id";
@@ -49,7 +61,7 @@ class LatestReceiptInfoTest extends TestCase
     /**
      * @test
      */
-    public function test_app_account_token()
+    public function app_account_token(): void
     {
         $value = $this->faker->uuid();
         $attributes = array_merge($this->commonAttributes, ['app_account_token' => $value]);
@@ -60,7 +72,7 @@ class LatestReceiptInfoTest extends TestCase
     /**
      * @test
      */
-    public function test_cancellation_date_ms()
+    public function cancellation_date_ms(): void
     {
         $value = $this->faker->unixTime() * 1000;
         $attributes = array_merge($this->commonAttributes, ['cancellation_date_ms' => $value]);
@@ -71,7 +83,7 @@ class LatestReceiptInfoTest extends TestCase
     /**
      * @test
      */
-    public function test_cancellation_reason()
+    public function cancellation_reason(): void
     {
         $reasons = [Cancellation::REASON_OTHER, Cancellation::REASON_APP_ISSUE];
         $value = $this->faker->randomElement($reasons);
@@ -83,7 +95,7 @@ class LatestReceiptInfoTest extends TestCase
     /**
      * @test
      */
-    public function test_expires_date_ms()
+    public function expires_date_ms(): void
     {
         $value = $this->faker->unixTime() * 1000;
         $attributes = array_merge($this->commonAttributes, ['expires_date_ms' => $value]);
@@ -94,7 +106,7 @@ class LatestReceiptInfoTest extends TestCase
     /**
      * @test
      */
-    public function test_in_app_ownership_type()
+    public function in_app_ownership_type(): void
     {
         $types = [
             LatestReceiptInfo::OWNERSHIP_TYPE_FAMILY_SHARED,
@@ -108,65 +120,42 @@ class LatestReceiptInfoTest extends TestCase
 
     /**
      * @test
+     * @dataProvider trueOrNullDataProvider
      */
-    public function test_is_in_intro_offer_period()
+    public function is_in_intro_offer_period(?string $value = null, ?bool $expected = null): void
     {
-        $values = ['true', true, 'false', false];
-        $value = $this->faker->randomElement($values);
         $attributes = array_merge($this->commonAttributes, ['is_in_intro_offer_period' => $value]);
         $latestReceiptInfo = LatestReceiptInfo::fromArray($attributes);
 
-        if ($value === 'false' || $value === false) {
-            $this->assertFalse($latestReceiptInfo->getIsInIntroOfferPeriod());
-        }
-
-        if ($value === 'true' || $value === true) {
-            $this->assertTrue($latestReceiptInfo->getIsInIntroOfferPeriod());
-        }
+        $this->assertEquals($expected, $latestReceiptInfo->getIsInIntroOfferPeriod());
     }
 
     /**
      * @test
+     * @dataProvider trueOrNullDataProvider
      */
-    public function test_is_trial_period()
+    public function is_trial_period(?string $value = null, ?bool $expected = null): void
     {
-        $values = ['true', true, 'false', false];
-        $value = $this->faker->randomElement($values);
         $attributes = array_merge($this->commonAttributes, ['is_trial_period' => $value]);
         $latestReceiptInfo = LatestReceiptInfo::fromArray($attributes);
-
-        if ($value === 'false' || $value === false) {
-            $this->assertFalse($latestReceiptInfo->getIsTrialPeriod());
-        }
-
-        if ($value === 'true' || $value === true) {
-            $this->assertTrue($latestReceiptInfo->getIsTrialPeriod());
-        }
+        $this->assertEquals($expected, $latestReceiptInfo->getIsTrialPeriod());
     }
 
     /**
      * @test
+     * @dataProvider trueOrNullDataProvider
      */
-    public function test_is_upgraded()
+    public function is_upgraded(?string $value = null, ?bool $expected = null): void
     {
-        $values = ['true', true];
-        $value = $this->faker->randomElement($values);
         $attributes = array_merge($this->commonAttributes, ['is_upgraded' => $value]);
         $latestReceiptInfo = LatestReceiptInfo::fromArray($attributes);
-
-        if ($value === 'false' || $value === false) {
-            $this->assertFalse($latestReceiptInfo->getIsUpgraded());
-        }
-
-        if ($value === 'true' || $value === true) {
-            $this->assertTrue($latestReceiptInfo->getIsUpgraded());
-        }
+        $this->assertEquals($expected, $latestReceiptInfo->getIsUpgraded());
     }
 
     /**
      * @test
      */
-    public function test_offer_code_ref_name()
+    public function offer_code_ref_name(): void
     {
         $value = 'fake_offer_code_ref_name';
         $attributes = array_merge($this->commonAttributes, ['offer_code_ref_name' => $value]);
@@ -177,7 +166,7 @@ class LatestReceiptInfoTest extends TestCase
     /**
      * @test
      */
-    public function test_original_purchase_date_ms()
+    public function original_purchase_date_ms(): void
     {
         $value = $this->faker->unixTime() * 1000;
         $attributes = array_merge($this->commonAttributes, ['original_purchase_date_ms' => $value]);
@@ -188,7 +177,7 @@ class LatestReceiptInfoTest extends TestCase
     /**
      * @test
      */
-    public function test_promotional_offer_id()
+    public function promotional_offer_id(): void
     {
         $value = 'fake_promotional_offer_id';
         $attributes = array_merge($this->commonAttributes, ['promotional_offer_id' => $value]);
@@ -199,7 +188,7 @@ class LatestReceiptInfoTest extends TestCase
     /**
      * @test
      */
-    public function test_purchase_date_ms()
+    public function purchase_date_ms(): void
     {
         $value = $this->faker->unixTime() * 1000;
         $attributes = array_merge($this->commonAttributes, ['purchase_date_ms' => $value]);
@@ -210,17 +199,19 @@ class LatestReceiptInfoTest extends TestCase
     /**
      * @test
      */
-    public function test_missing_data_is_null()
+    public function missing_data_is_null(): void
     {
         $notNullGetters = [
             'getQuantity',
             'getProductId',
             'getTransactionId',
             'getOriginalTransactionId',
+            'getIsTrialPeriod',
+            'getIsUpgraded',
         ];
 
         $latestReceiptInfo = LatestReceiptInfo::fromArray($this->commonAttributes);
-        $getters = array_filter(get_class_methods($latestReceiptInfo), function (string $method) use ($notNullGetters) {
+        $getters = array_filter(get_class_methods($latestReceiptInfo), static function (string $method) use ($notNullGetters) {
             $isGetter = strpos($method, 'get') !== false;
             $isNullGetter = ! in_array($method, $notNullGetters);
 
@@ -230,5 +221,27 @@ class LatestReceiptInfoTest extends TestCase
         foreach ($getters as $getter) {
             $this->assertNull($latestReceiptInfo->$getter());
         }
+    }
+
+    /**
+     * @deprecated
+     * @test
+     */
+    public function get_cancellation(): void
+    {
+        $now = time() * 1000;
+
+        $attributes = array_merge($this->commonAttributes, [
+            'cancellation_date_ms' => $now,
+            'cancellation_reason' => LatestReceiptInfo::CANCELLATION_REASON_APP_ISSUE,
+        ]);
+
+        $latestReceiptInfo = LatestReceiptInfo::fromArray($attributes);
+
+        $cancellation = $latestReceiptInfo->getCancellation();
+
+        $cancellationTime = $cancellation->getTime()->toDateTime();
+        $this->assertEquals((new Time($now))->toDateTime(), $cancellationTime);
+        $this->assertEquals(LatestReceiptInfo::CANCELLATION_REASON_APP_ISSUE, $cancellation->getReason());
     }
 }


### PR DESCRIPTION
**What?**

- Deprecated cancellation value object.
- Use php7.4 syntax on value objects
- Update test cases

**Does your code follow the PSR-12 standard?** _(Yes|No)_.

Yes

**Does the psalm tool show no errors?** _(Yes|No)_.

No

**Are there unit tests related to this PR?** _(Yes|No)_.

Yes
