### PR TITLE
[1.x] Get raw response data

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,7 +10,7 @@ Mention the related issue, either a feature request or a bug report.
 
 Describe your solution to the problem.
 
-**Does your code follow the PSR-2 standard?** _(Yes|No)_.
+**Does your code follow the PSR-12 standard?** _(Yes|No)_.
 
 Answer: ...
 

--- a/src/Contracts/Arrayable.php
+++ b/src/Contracts/Arrayable.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Imdhemy\AppStore\Contracts;
+
+/**
+ * Interface Arrayable
+ */
+interface Arrayable
+{
+    /**
+     * Convert the object to its array representation.
+     *
+     * @return array
+     */
+    public function toArray(): array;
+}

--- a/src/Receipts/ReceiptResponse.php
+++ b/src/Receipts/ReceiptResponse.php
@@ -83,6 +83,11 @@ class ReceiptResponse implements Arrayable
     private bool $parsedPendingRenewalInfo;
 
     /**
+     * @var array The raw data from the response.
+     */
+    private array $body;
+
+    /**
      * ReceiptResponse Constructor
      */
     private function __construct(int $status)
@@ -102,6 +107,7 @@ class ReceiptResponse implements Arrayable
     public static function fromArray(array $body): self
     {
         $obj = new self($body['status']);
+        $obj->body = $body;
 
         $obj->environment = $body['environment'] ?? null;
         $obj->isRetryable = $body['is-retryable'] ?? null;
@@ -210,6 +216,6 @@ class ReceiptResponse implements Arrayable
      */
     public function toArray(): array
     {
-        return [];
+        return $this->body;
     }
 }

--- a/src/Receipts/ReceiptResponse.php
+++ b/src/Receipts/ReceiptResponse.php
@@ -9,68 +9,77 @@ use Imdhemy\AppStore\ValueObjects\Status;
 
 /**
  * Class ReceiptResponse
+ *
+ * @see     https://developer.apple.com/documentation/appstorereceipts/responsebody
  * @package Imdhemy\AppStore\Receipts
- * @see https://developer.apple.com/documentation/appstorereceipts/responsebody
  */
 class ReceiptResponse
 {
     public const ENV_SANDBOX = 'Sandbox';
+
     public const ENV_PRODUCTION = 'Production';
 
     /**
      * The environment for which the receipt was generated.
+     *
      * @var string|null
      */
-    protected $environment;
+    protected ?string $environment;
 
     /**
      * An indicator that an error occurred during the request.
+     *
      * @var bool|null
      */
-    protected $isRetryable;
+    protected ?bool $isRetryable;
 
     /**
      * The latest Base64 encoded app receipt.
      * Only returned for receipts that contain auto-renewable subscriptions.
+     *
      * @var string|null
      */
-    protected $latestReceipt;
+    protected ?string $latestReceipt;
 
     /**
      * An array that contains all in-app purchase transactions.
+     *
      * @var array|LatestReceiptInfo[]|null
      */
-    protected $latestReceiptInfo;
+    protected ?array $latestReceiptInfo;
 
     /**
      * In the JSON file, an array where each element contains the pending renewal information
      * for each auto-renewable subscription identified by the product_id.
+     *
      * @var array|PendingRenewal[]|null
      */
-    protected $pendingRenewalInfo;
+    protected ?array $pendingRenewalInfo;
 
     /**
      * the receipt that was sent for verification.
+     *
      * @var array|null
      */
-    protected $receipt;
+    protected ?array $receipt;
 
     /**
-     * Either 0 if the receipt is valid, or a status code if there is an error.
+     * Either `0` if the receipt is valid, or a status code if there is an error.
+     *
      * @see https://developer.apple.com/documentation/appstorereceipts/status
      * @var int
      */
-    protected $status;
+    protected int $status;
 
     /**
      * @var bool
      */
-    private $parsedLatestReceiptInfo;
+    private bool $parsedLatestReceiptInfo;
 
     /**
      * @var bool
      */
-    private $parsedPendingRenewalInfo;
+    private bool $parsedPendingRenewalInfo;
 
     /**
      * ReceiptResponse Constructor
@@ -84,7 +93,9 @@ class ReceiptResponse
 
     /**
      * Static factory method
+     *
      * @param array $body
+     *
      * @return ReceiptResponse
      */
     public static function fromArray(array $body): self

--- a/src/Receipts/ReceiptResponse.php
+++ b/src/Receipts/ReceiptResponse.php
@@ -2,6 +2,7 @@
 
 namespace Imdhemy\AppStore\Receipts;
 
+use Imdhemy\AppStore\Contracts\Arrayable;
 use Imdhemy\AppStore\ValueObjects\LatestReceiptInfo;
 use Imdhemy\AppStore\ValueObjects\PendingRenewal;
 use Imdhemy\AppStore\ValueObjects\Receipt;
@@ -13,7 +14,7 @@ use Imdhemy\AppStore\ValueObjects\Status;
  * @see     https://developer.apple.com/documentation/appstorereceipts/responsebody
  * @package Imdhemy\AppStore\Receipts
  */
-class ReceiptResponse
+class ReceiptResponse implements Arrayable
 {
     public const ENV_SANDBOX = 'Sandbox';
 
@@ -84,7 +85,7 @@ class ReceiptResponse
     /**
      * ReceiptResponse Constructor
      */
-    public function __construct(int $status)
+    private function __construct(int $status)
     {
         $this->status = $status;
         $this->parsedLatestReceiptInfo = false;
@@ -202,5 +203,13 @@ class ReceiptResponse
     public function getStatus(): Status
     {
         return new Status($this->status);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function toArray(): array
+    {
+        return [];
     }
 }

--- a/src/Receipts/ReceiptResponse.php
+++ b/src/Receipts/ReceiptResponse.php
@@ -85,12 +85,16 @@ class ReceiptResponse implements Arrayable
     /**
      * @var array The raw data from the response.
      */
-    private array $body;
+    private array $rawBody = [];
 
     /**
      * ReceiptResponse Constructor
+     *
+     * @deprecated Use ReceiptResponse::fromArray() instead.
+     * This constructor will be private in the next major release.
+     * Using it will result in inaccessibility to the response body as an array.
      */
-    private function __construct(int $status)
+    public function __construct(int $status)
     {
         $this->status = $status;
         $this->parsedLatestReceiptInfo = false;
@@ -107,7 +111,7 @@ class ReceiptResponse implements Arrayable
     public static function fromArray(array $body): self
     {
         $obj = new self($body['status']);
-        $obj->body = $body;
+        $obj->rawBody = $body;
 
         $obj->environment = $body['environment'] ?? null;
         $obj->isRetryable = $body['is-retryable'] ?? null;
@@ -216,6 +220,6 @@ class ReceiptResponse implements Arrayable
      */
     public function toArray(): array
     {
-        return $this->body;
+        return $this->rawBody;
     }
 }

--- a/src/ValueObjects/LatestReceiptInfo.php
+++ b/src/ValueObjects/LatestReceiptInfo.php
@@ -2,12 +2,14 @@
 
 namespace Imdhemy\AppStore\ValueObjects;
 
+use Imdhemy\AppStore\Contracts\Arrayable;
+
 /**
  * LatestReceiptInfo class which contains in-app purchase transaction
  *
  * @link https://developer.apple.com/documentation/appstorereceipts/responsebody/latest_receipt_info
  */
-final class LatestReceiptInfo
+final class LatestReceiptInfo implements Arrayable
 {
     /**
      * @const string The transaction belongs to a family member who benefits from service.
@@ -172,10 +174,19 @@ final class LatestReceiptInfo
     private string $transactionId;
 
     /**
+     * @var array The raw data from the App Store
+     */
+    private array $rawBody = [];
+
+    /**
      * @param string $originalTransactionId
      * @param string $productId
      * @param int $quantity
      * @param string $transactionId
+     *
+     * @deprecated Use LatestReceiptInfo::fromArray() instead.
+     * This constructor will be private in the next major release.
+     * Using it will result in inaccessibility to the response raw body as an array.
      */
     public function __construct(string $originalTransactionId, string $productId, int $quantity, string $transactionId)
     {
@@ -198,6 +209,8 @@ final class LatestReceiptInfo
             $attributes['quantity'],
             $attributes['transaction_id']
         );
+
+        $obj->rawBody = $attributes;
 
         $obj->appAccountToken = $attributes['app_account_token'] ?? null;
         $obj->cancellationDate = $attributes['cancellation_date_ms'] ?? null;
@@ -399,5 +412,13 @@ final class LatestReceiptInfo
         }
 
         return $this->isUpgraded;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function toArray(): array
+    {
+        return $this->rawBody;
     }
 }

--- a/tests/Receipts/ReceiptResponseTest.php
+++ b/tests/Receipts/ReceiptResponseTest.php
@@ -16,7 +16,8 @@ class ReceiptResponseTest extends TestCase
      */
     public function all_attributes_are_optional_except_status(): void
     {
-        $response = new ReceiptResponse(0);
+        $response = ReceiptResponse::fromArray(['status' => 0]);
+        
         $this->assertInstanceOf(ReceiptResponse::class, $response);
     }
 

--- a/tests/Receipts/ReceiptResponseTest.php
+++ b/tests/Receipts/ReceiptResponseTest.php
@@ -17,7 +17,7 @@ class ReceiptResponseTest extends TestCase
     public function all_attributes_are_optional_except_status(): void
     {
         $this->expectNotToPerformAssertions();
-        
+
         ReceiptResponse::fromArray(['status' => 0]);
     }
 
@@ -146,5 +146,22 @@ class ReceiptResponseTest extends TestCase
 
         $response = ReceiptResponse::fromArray(['status' => $value,]);
         $this->assertEquals($value, $response->getStatus()->getValue());
+    }
+
+    /**
+     * @test
+     */
+    public function to_array_should_return_all_attributes(): void
+    {
+        $body = [
+            'status' => 0,
+            'environment' => ReceiptResponse::ENV_PRODUCTION,
+            'is-retryable' => 'true',
+            'latest_receipt' => 'fake_receipt_content',
+        ];
+
+        $response = ReceiptResponse::fromArray($body);
+
+        $this->assertEquals($body, $response->toArray());
     }
 }

--- a/tests/Receipts/ReceiptResponseTest.php
+++ b/tests/Receipts/ReceiptResponseTest.php
@@ -16,9 +16,9 @@ class ReceiptResponseTest extends TestCase
      */
     public function all_attributes_are_optional_except_status(): void
     {
-        $response = ReceiptResponse::fromArray(['status' => 0]);
+        $this->expectNotToPerformAssertions();
         
-        $this->assertInstanceOf(ReceiptResponse::class, $response);
+        ReceiptResponse::fromArray(['status' => 0]);
     }
 
     /**

--- a/tests/Receipts/ReceiptResponseTest.php
+++ b/tests/Receipts/ReceiptResponseTest.php
@@ -7,7 +7,6 @@ use Imdhemy\AppStore\Receipts\ReceiptResponse;
 use Imdhemy\AppStore\ValueObjects\LatestReceiptInfo;
 use Imdhemy\AppStore\ValueObjects\PendingRenewal;
 use Imdhemy\AppStore\ValueObjects\Receipt;
-use Imdhemy\AppStore\ValueObjects\Status;
 use PHPUnit\Framework\TestCase;
 
 class ReceiptResponseTest extends TestCase
@@ -15,7 +14,7 @@ class ReceiptResponseTest extends TestCase
     /**
      * @test
      */
-    public function test_all_attributes_are_optional_except_status()
+    public function all_attributes_are_optional_except_status(): void
     {
         $response = new ReceiptResponse(0);
         $this->assertInstanceOf(ReceiptResponse::class, $response);
@@ -24,7 +23,7 @@ class ReceiptResponseTest extends TestCase
     /**
      * @test
      */
-    public function test_environment_attribute()
+    public function environment_attribute(): void
     {
         $environments = [ReceiptResponse::ENV_PRODUCTION, ReceiptResponse::ENV_SANDBOX];
 
@@ -44,7 +43,7 @@ class ReceiptResponseTest extends TestCase
      * @test
      * @throws Exception
      */
-    public function test_is_retryable()
+    public function is_retryable(): void
     {
         $value = random_int(0, 1);
         $body = ['is-retryable' => $value, 'status' => 0];
@@ -59,7 +58,7 @@ class ReceiptResponseTest extends TestCase
     /**
      * @test
      */
-    public function test_latest_receipt()
+    public function latest_receipt(): void
     {
         $value = base64_decode("fake_receipt_content");
         $response = ReceiptResponse::fromArray(['latest_receipt' => $value, 'status' => 0]);
@@ -73,7 +72,7 @@ class ReceiptResponseTest extends TestCase
     /**
      * @test
      */
-    public function test_latest_receipt_info()
+    public function latest_receipt_info(): void
     {
         $value = [];
         $response = ReceiptResponse::fromArray(['latest_receipt_info' => $value, 'status' => 0]);
@@ -99,7 +98,7 @@ class ReceiptResponseTest extends TestCase
     /**
      * @test
      */
-    public function test_pending_renewal_info()
+    public function pending_renewal_info(): void
     {
         $value = [];
         $response = ReceiptResponse::fromArray(['pending_renewal_info' => $value, 'status' => 0]);
@@ -125,7 +124,7 @@ class ReceiptResponseTest extends TestCase
     /**
      * @test
      */
-    public function test_receipt()
+    public function receipt(): void
     {
         $value = [];
         $response = ReceiptResponse::fromArray(['receipt' => $value, 'status' => 0]);
@@ -139,13 +138,12 @@ class ReceiptResponseTest extends TestCase
     /**
      * @test
      */
-    public function test_status()
+    public function status(): void
     {
         $statusList = array_merge([0], range(21000, 21010));
         $value = $statusList[array_rand($statusList)];
 
         $response = ReceiptResponse::fromArray(['status' => $value,]);
-        $this->assertInstanceOf(Status::class, $response->getStatus());
         $this->assertEquals($value, $response->getStatus()->getValue());
     }
 }

--- a/tests/ValueObjects/LatestReceiptInfoTest.php
+++ b/tests/ValueObjects/LatestReceiptInfoTest.php
@@ -246,4 +246,31 @@ class LatestReceiptInfoTest extends TestCase
         $this->assertEquals((new Time($now))->toDateTime(), $cancellationTime);
         $this->assertEquals(LatestReceiptInfo::CANCELLATION_REASON_APP_ISSUE, $cancellation->getReason());
     }
+
+    /**
+     * @test
+     */
+    public function get_web_order_line_item_id(): void
+    {
+        $value = 'fake_web_order_line_item_id';
+        $attributes = array_merge($this->commonAttributes, ['web_order_line_item_id' => $value]);
+        $latestReceiptInfo = LatestReceiptInfo::fromArray($attributes);
+        $this->assertEquals($value, $latestReceiptInfo->getWebOrderLineItemId());
+    }
+
+    /**
+     * @test
+     */
+    public function to_array(): void
+    {
+        $attributes = array_merge($this->commonAttributes, [
+            'cancellation_date_ms' => $this->faker->unixTime() * 1000,
+            'cancellation_reason' => LatestReceiptInfo::CANCELLATION_REASON_APP_ISSUE,
+            'web_order_line_item_id' => 'fake_web_order_line_item_id',
+        ]);
+
+        $latestReceiptInfo = LatestReceiptInfo::fromArray($attributes);
+
+        $this->assertEquals($attributes, $latestReceiptInfo->toArray());
+    }
 }


### PR DESCRIPTION
**What?**

- Get raw response data

**Why?**

Closes #19 

**How?**

Both `ReceiptResponse` and `LatestReceiptInfo` now has `toArray()` method.

**Does your code follow the PSR-12 standard?** _(Yes|No)_.

Yes

**Does the psalm tool show no errors?** _(Yes|No)_.

No

**Are there unit tests related to this PR?** _(Yes|No)_.

Yes
