### PR TITLE
Draft: Add AppStoreServer API

### DIFF
--- a/src/ServerAPI/AppStoreServer.php
+++ b/src/ServerAPI/AppStoreServer.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Imdhemy\AppStore\ServerAPI;
+
+/**
+ * This class is used to build AppStoreServer service
+ */
+class AppStoreServer
+{
+    private AppStoreServerService $service;
+
+    public function __construct(array $config, string $version)
+    {
+        $this->service = (new AppStoreServerBuilder)->of($config)->version($version)->build();
+    }
+
+    public function service(): AppStoreServerService
+    {
+        return $this->service;
+    }
+
+    public function parseResponse($response): mixed
+    {
+        return json_decode($response->getBody()->getContents(), true, 512, JSON_THROW_ON_ERROR);
+    }
+}

--- a/src/ServerAPI/AppStoreServerBuilder.php
+++ b/src/ServerAPI/AppStoreServerBuilder.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Imdhemy\AppStore\ServerAPI;
+
+use GuzzleHttp\ClientInterface;
+use Imdhemy\AppStore\ClientFactory;
+use Imdhemy\AppStore\Jws\AppStoreJwsGenerator;
+use Imdhemy\AppStore\Jws\GeneratorConfig;
+use Imdhemy\AppStore\Jws\Issuer;
+use Imdhemy\AppStore\Jws\Key;
+use Lcobucci\JWT\Signer\Ecdsa\Sha256;
+use Lcobucci\JWT\Signer\Key\InMemory;
+use RuntimeException;
+
+/**
+ * This class is used to build AppStoreServiceBuilder.
+ */
+class AppStoreServerBuilder
+{
+    protected bool $sandbox = false;
+
+    private ?string $issuerId = null;
+
+    private ?string $bundleId = null;
+
+    private ?string $privateKeyId = null;
+
+    private ?string $privateKey = null;
+
+    private ?string $version = 'v2';
+
+    /**
+     * Builds a new instance of AppStoreTestNotificationService.
+     */
+    public function build(): AppStoreServerService
+    {
+        assert(is_string($this->issuerId) && ! empty($this->issuerId));
+        assert(is_string($this->bundleId) && ! empty($this->bundleId));
+        assert(is_string($this->privateKeyId) && ! empty($this->privateKeyId));
+        assert(is_string($this->privateKey) && ! empty($this->privateKey));
+
+        $config = GeneratorConfig::forAppStore(
+            new Issuer(
+                $this->issuerId,
+                $this->bundleId,
+                new Key($this->privateKeyId, InMemory::plainText($this->privateKey)),
+                new Sha256
+            ),
+        );
+        $jwsGenerator = new AppStoreJwsGenerator($config);
+
+        $client = $this->createClient();
+
+        return new AppStoreServerService($client, $jwsGenerator, $this->version);
+    }
+
+    /**
+     * @return $this
+     */
+    public function issuerId(string $issuerId): self
+    {
+        $this->issuerId = $issuerId;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function bundleId(string $bundleId): self
+    {
+        $this->bundleId = $bundleId;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function privateKeyId(string $privateKeyId): self
+    {
+        $this->privateKeyId = $privateKeyId;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function privateKey(string $privateKey): self
+    {
+        $this->privateKey = $privateKey;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function sandbox(bool $sandbox): self
+    {
+        $this->sandbox = $sandbox;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function version(string $version = 'v2'): self
+    {
+        $this->version = $version;
+
+        return $this;
+    }
+
+    protected function createClient(): ClientInterface
+    {
+        return $this->sandbox ? ClientFactory::createForStoreKitSandbox() : ClientFactory::createForStoreKit();
+    }
+
+    public function of(array $config): self
+    {
+        $keys = [
+            'appstore_private_key_id' => 'private key ID',
+            'appstore_private_key' => 'private key',
+            'appstore_issuer_id' => 'issuer ID',
+            'appstore_bundle_id' => 'bundle ID',
+        ];
+
+        foreach ($keys as $key => $value) {
+            if (! array_key_exists($key, $config) || empty($config[$key])) {
+                throw new RuntimeException("The $value is not configured");
+            }
+        }
+
+        assert(is_string($config['appstore_private_key_id']));
+        assert(is_string($config['appstore_private_key']));
+        assert(is_string($config['appstore_issuer_id']));
+        assert(is_string($config['appstore_bundle_id']));
+        assert(is_bool($config['sandbox']));
+
+        $this->privateKeyId($config['appstore_private_key_id']);
+        $this->privateKey(file_get_contents($config['appstore_private_key']));
+        $this->issuerId($config['appstore_issuer_id']);
+        $this->bundleId($config['appstore_bundle_id']);
+        $this->sandbox($config['sandbox']);
+
+        return $this;
+    }
+}

--- a/src/ServerAPI/AppStoreServerService.php
+++ b/src/ServerAPI/AppStoreServerService.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Imdhemy\AppStore\ServerAPI;
+
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Exception\GuzzleException;
+use Imdhemy\AppStore\Jws\JwsGenerator;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Class AppStoreServerService
+ * This class is used to request from App Store Server
+ */
+final class AppStoreServerService
+{
+    private ClientInterface $client;
+
+    private JwsGenerator $jwsGenerator;
+
+    private string $version = 'v1';
+
+    public function __construct(ClientInterface $client, JwsGenerator $jwsGenerator, string $version = 'v1')
+    {
+        $this->client = $client;
+        $this->jwsGenerator = $jwsGenerator;
+        $this->version = $version;
+    }
+
+    public function get(string $url, $params = []): ResponseInterface
+    {
+        return $this->request($url, 'get', $params);
+    }
+
+    public function post(string $url, array $data): ResponseInterface
+    {
+        return $this->request($url, 'post', [], $data);
+    }
+
+    /**
+     * Sends requests to App Store Server
+     *
+     * @throws GuzzleException
+     */
+    public function request(string $url, $type = 'get', $params = [], $data = null): ResponseInterface
+    {
+        $jws = $this->jwsGenerator->generate();
+
+        $url = str_replace('//', '/', '/inApps/'.$this->version.'/'.$url);
+
+        return $this->client->{$type}($url, [
+            'headers' => [
+                'Authorization' => sprintf('Bearer %s', $jws),
+            ],
+            'query' => $params,
+            'form_params' => $data,
+        ]);
+    }
+}

--- a/src/ServerAPI/AppStoreServerV1.php
+++ b/src/ServerAPI/AppStoreServerV1.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Imdhemy\AppStore\ServerAPI;
+
+use Imdhemy\AppStore\Jws\Parser;
+use Imdhemy\AppStore\ValueObjects\ConsumptionRequest;
+use Imdhemy\AppStore\ValueObjects\JwsTransactionInfo;
+
+/**
+ * This class is used to build AppStoreServerV1 service and requests
+ */
+class AppStoreServerV1 extends AppStoreServer
+{
+    public function __construct($config)
+    {
+        parent::__construct($config, 'v1');
+    }
+
+    /*
+    * Send Consumption Information
+     *
+    * https://developer.apple.com/documentation/appstoreserverapi/send-consumption-information
+     *
+    */
+    public function sendConsumption($transactionId, ConsumptionRequest $consumption)
+    {
+        $response = $this->service()->get("transactions/consumption/$transactionId}", $consumption->toArray());
+
+        return $this->parseResponse($response);
+    }
+
+    /*
+    * Get a customer’s in-app purchases from a receipt using the order ID.
+     *
+     * When customers make one or more in-app purchases in your app, the App Store emails them a receipt.
+     * The receipt contains an order ID. Use this order ID to call Look Up Order ID. Customers can also
+     * retrieve their order IDs from their purchase history on the App Store; for more information,
+     * see See your purchase history for the App Store, iTunes store, and more.
+     *
+    * https://developer.apple.com/documentation/appstoreserverapi/look-up-order-id
+     *
+    */
+    public function order($orderId)
+    {
+        $response = $this->service()->get("lookup/$orderId");
+
+        return $this->parseResponse($response);
+    }
+
+    /*
+    * Get information about a single transaction for your app.
+     *
+    * https://developer.apple.com/documentation/appstoreserverapi/get-transaction-info
+     *
+    */
+    public function transaction($transactionId): JwsTransactionInfo
+    {
+        $response = $this->service()->get("transactions/$transactionId");
+
+        return new JwsTransactionInfo(Parser::toJws($this->parseResponse($response)['signedTransactionInfo']));
+    }
+
+    /*
+    * Validate a transaction with the App Store Server
+     *
+    * Returns a JwsTransactionInfo
+     *
+    */
+    public function validateTransaction($transactionId): JwsTransactionInfo
+    {
+        return $this->transaction($transactionId);
+    }
+
+    /*
+     * Get the statuses for all of a customer’s auto-renewable subscriptions in your app.
+     *
+     * https://developer.apple.com/documentation/appstoreserverapi/get-all-subscription-statuses
+     *
+     * transactionId (Required) The identifier of a transaction that belongs to the customer, and which may be an original transaction identifier
+     * $status (optional) An optional filter that indicates the status of subscriptions to include in the response. Your query may specify more than one status query parameter.
+     */
+    public function subscriptions($transactionId, ?int $status = null)
+    {
+        $params = [];
+
+        if (! is_null($status)) {
+            $params['status'] = $status;
+        }
+
+        $response = $this->service()->get("subscriptions/$transactionId", $params);
+
+        return $this->parseResponse($response);
+    }
+
+    /*
+     * Ask App Store Server to send a test notification to your server.
+     */
+    public function requestTestNotification(): string
+    {
+        $response = $this->service()->get('notifications/test');
+
+        $content = $this->parseResponse($response);
+
+        assert(is_array($content) && array_key_exists('testNotificationToken', $content));
+
+        $token = $content['testNotificationToken'];
+
+        assert(is_string($token));
+
+        return $token;
+    }
+}

--- a/src/ServerAPI/AppStoreServerV2.php
+++ b/src/ServerAPI/AppStoreServerV2.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Imdhemy\AppStore\ServerAPI;
+
+/**
+ * This class is used to build AppStoreServerV2 requests
+ */
+class AppStoreServerV2 extends AppStoreServer
+{
+    public function __construct($config)
+    {
+        parent::__construct($config, 'v2');
+    }
+
+    /*
+     * Get Transaction History
+     * Get a customer’s in-app purchase transaction history for your app.
+     *
+     * https://developer.apple.com/documentation/appstoreserverapi/get-transaction-history
+     */
+    public function history($transactionId): mixed
+    {
+        $response = $this->service()->get("history/$transactionId");
+
+        return $this->parseResponse($response);
+    }
+}

--- a/src/ValueObjects/ConsumptionRequest.php
+++ b/src/ValueObjects/ConsumptionRequest.php
@@ -1,0 +1,207 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Imdhemy\AppStore\ValueObjects;
+
+class ConsumptionRequest
+{
+    private $accountTenure;
+
+    private $appAccountToken;
+
+    private $consumptionStatus;
+
+    private $customerConsented;
+
+    private $deliveryStatus;
+
+    private $lifetimeDollarsPurchased;
+
+    private $lifetimeDollarsRefunded;
+
+    private $platform;
+
+    private $playTime;
+
+    private $refundPreference;
+
+    private $sampleContentProvided;
+
+    private $userStatus;
+
+    /**
+     * The age of the customer's account.
+     * (Required)
+     *
+     * https://developer.apple.com/documentation/appstoreserverapi/accounttenure
+     */
+    public function accountTenure($value)
+    {
+        $this->accountTenure = $value;
+
+        return $this;
+    }
+
+    /**
+     * The UUID of the in-app user account that completed the in-app purchase transaction.
+     * (Required)
+     *
+     * https://developer.apple.com/documentation/appstoreserverapi/appaccounttoken
+     */
+    public function appAccountToken($value)
+    {
+        $this->appAccountToken = $value;
+
+        return $this;
+    }
+
+    /**
+     * A value that indicates the extent to which the customer consumed the in-app purchase.
+     * (Required)
+     *
+     * https://developer.apple.com/documentation/appstoreserverapi/consumptionstatus
+     */
+    public function consumptionStatus($value)
+    {
+        $this->consumptionStatus = $value;
+
+        return $this;
+    }
+
+    /**
+     * A Boolean value of true or false that indicates whether the customer consented to provide consumption data.
+     * Note: The App Store server rejects requests that have a customerConsented value other than true by returning an HTTP 400 error with an InvalidCustomerConsentError.
+     * (Required)
+     *
+     * https://developer.apple.com/documentation/appstoreserverapi/customerconsented
+     */
+    public function customerConsented($value)
+    {
+        $this->customerConsented = $value;
+
+        return $this;
+    }
+
+    /**
+     * A value that indicates whether the app successfully delivered an in-app purchase that works properly.
+     * (Required)
+     *
+     * https://developer.apple.com/documentation/appstoreserverapi/deliverystatus
+     */
+    public function deliveryStatus($value)
+    {
+        $this->deliveryStatus = $value;
+
+        return $this;
+    }
+
+    /**
+     * A value that indicates the total amount, in USD, of in-app purchases the customer has made in your app, across all platforms.
+     * (Required)
+     *
+     * https://developer.apple.com/documentation/appstoreserverapi/lifetimedollarspurchased
+     */
+    public function lifetimeDollarsPurchased($value)
+    {
+        $this->lifetimeDollarsPurchased = $value;
+
+        return $this;
+    }
+
+    /**
+     * A value that indicates the total amount, in USD, of refunds the customer has received, in your app, across all platforms.
+     * (Required)
+     *
+     *  https://developer.apple.com/documentation/appstoreserverapi/lifetimedollarsrefunded
+     */
+    public function lifetimeDollarsRefunded($value)
+    {
+        $this->lifetimeDollarsRefunded = $value;
+
+        return $this;
+    }
+
+    /**
+     * A value that indicates the platform on which the customer consumed the in-app purchase.
+     * (Required)
+     *
+     * https://developer.apple.com/documentation/appstoreserverapi/platform
+     */
+    public function platform($value)
+    {
+        $this->platform = $value;
+
+        return $this;
+    }
+
+    /**
+     * A value that indicates the amount of time that the customer used the app.
+     * (Required)
+     *
+     * https://developer.apple.com/documentation/appstoreserverapi/playtime
+     */
+    public function playTime($value)
+    {
+        $this->playTime = $value;
+
+        return $this;
+    }
+
+    /**
+     * A value that indicates your preference, based on your operational logic, as to whether Apple should grant the refund.
+     * (Optional)
+     *
+     * https://developer.apple.com/documentation/appstoreserverapi/refundpreference
+     */
+    public function refundPreference($value)
+    {
+        $this->refundPreference = $value;
+
+        return $this;
+    }
+
+    /**
+     * A Boolean value of true or false that indicates whether you provided, prior to its purchase, a free sample or trial of the content, or information about its functionality.
+     * (Required)
+     *
+     * https://developer.apple.com/documentation/appstoreserverapi/samplecontentprovided
+     */
+    public function sampleContentProvided($value)
+    {
+        $this->sampleContentProvided = $value;
+
+        return $this;
+    }
+
+    /**
+     * The status of the customer's account.
+     * (Required)
+     *
+     * https://developer.apple.com/documentation/appstoreserverapi/userstatus
+     */
+    public function userStatus($value)
+    {
+        $this->userStatus = $value;
+
+        return $this;
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'accountTenure' => $this->accountTenure,
+            'appAccountToken' => $this->appAccountToken,
+            'consumptionStatus' => $this->consumptionStatus,
+            'customerConsented' => $this->customerConsented,
+            'deliveryStatus' => $this->deliveryStatus,
+            'lifetimeDollarsPurchased' => $this->lifetimeDollarsPurchased,
+            'lifetimeDollarsRefunded' => $this->lifetimeDollarsRefunded,
+            'platform' => $this->platform,
+            'playTime' => $this->playTime,
+            'refundPreference' => $this->refundPreference ?? null,
+            'sampleContentProvided' => $this->sampleContentProvided,
+            'userStatus' => $this->userStatus,
+        ];
+    }
+}

--- a/src/ValueObjects/SubscriptionStatus.php
+++ b/src/ValueObjects/SubscriptionStatus.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Imdhemy\AppStore\ValueObjects;
+
+use Stringable;
+
+/*
+ * Subscription statuses for querying the App Store Server Api
+ *
+ * @see https://developer.apple.com/documentation/appstoreserverapi/status
+ *
+ * transactionId (Required) The identifier of a transaction that belongs to the customer, and which may be an original transaction identifier
+ * $status (optional) An optional filter that indicates the status of subscriptions to include in the response. Your query may specify more than one status query parameter.
+ *
+ * 1 - The auto-renewable subscription is active.
+ * 2- The auto-renewable subscription is expired.
+ * 3 - The auto-renewable subscription is in a billing retry period.
+ * 4 - The auto-renewable subscription is in a Billing Grace Period.
+ * 5 - The auto-renewable subscription is revoked. The App Store refunded the transaction or revoked it from Family Sharing.
+ */
+final class SubscriptionStatus implements Stringable
+{
+    public const ACTIVE = 1;
+
+    public const EXPIRED = 2;
+
+    public const BILLING_RETRY_PERIOD = 3;
+
+    public const BILLING_GRACE_PERIOD = 4;
+
+    public const REVOKED = 5;
+
+    private int $value;
+
+    public function __construct(int $value)
+    {
+        $this->value = $value;
+    }
+
+    public function getValue(): int
+    {
+        return $this->value;
+    }
+
+    public function __toString(): string
+    {
+        return (string) $this->getValue();
+    }
+}


### PR DESCRIPTION
This is a quick and dirty outline for using this codebase to interact with the App Store Server API (v1/v2): https://developer.apple.com/documentation/appstoreserverapi

I personally needed a quick way to verify transactions against the App Store server since verifyReceipt() doesn't work with StoreKit2.

I've included quick implementations of:

1. Requesting a test notification (v1)
2. Consumption request (v1)
3. Transaction history (v2)

However, class objects/enums and request parameters still need to be fully fleshed out.

I noticed a few discussions around this topic: 
- https://github.com/imdhemy/appstore-iap/discussions/188
- https://github.com/imdhemy/laravel-in-app-purchases/discussions/474
- https://github.com/imdhemy/laravel-in-app-purchases/discussions/415

I think with a base structure in place it will be quick work for other contributors to fill out the rest

@imdhemy, if you can confirm this is a good structure (or suggest one the works with your codebase) and someone wants to help work on this, I'd be more than happy to contribute more. Unfortunately, I'm racing against the clock to get some work out just at this moment.


https://github.com/imdhemy/appstore-iap/issues/27
https://github.com/imdhemy/appstore-iap/issues/28